### PR TITLE
Added .count method and :skip option

### DIFF
--- a/lib/Leaderboard.d.ts
+++ b/lib/Leaderboard.d.ts
@@ -1,0 +1,27 @@
+import { Collection, Db } from 'mongodb';
+import { ListOptions } from './Leaderboard';
+export interface CreateOptions {
+    ttl?: number;
+}
+export interface ListOptions {
+    limit?: number;
+    skip?: number;
+}
+export interface RecordOptions {
+    id: any;
+    score: number;
+    expireAt?: number;
+}
+export declare class Leaderboard {
+    private db;
+    constructor(db: Db);
+    create(leaderboardId: string, opts?: CreateOptions): Promise<void>;
+    destroy(leaderboardId: string): Promise<any>;
+    record(leaderboardId: string, record: any & RecordOptions, expireAt?: number): Promise<any>;
+    list(leaderboardId: string, opts?: ListOptions): Promise<any[]>;
+    get(leaderboardId: string, id: any): Promise<any>;
+    count(leaderboardId: string): Promise<number>;
+    position(leaderboardId: string, id: any): Promise<number>;
+    surrounding(leaderboardId: string, id: any, opts?: ListOptions): Promise<any[]>;
+    protected getCollection(leaderboardId: string): Collection<any>;
+}

--- a/lib/Leaderboard.js
+++ b/lib/Leaderboard.js
@@ -1,0 +1,111 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+class Leaderboard {
+    constructor(db) {
+        this.db = db;
+    }
+    create(leaderboardId, opts) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const collection = this.getCollection(leaderboardId);
+            const spec = (opts.ttl)
+                ? { createdAt: 1 }
+                : { expireAt: 1 };
+            const options = (opts.ttl)
+                ? { expireAfterSeconds: opts.ttl }
+                : { expireAfterSeconds: 0 };
+            yield collection.createIndex(spec, options);
+            yield collection.createIndex({ score: -1 });
+            yield collection.createIndex({ id: 1 });
+        });
+    }
+    destroy(leaderboardId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const collection = this.getCollection(leaderboardId);
+            yield collection.dropIndexes();
+            return collection.drop();
+        });
+    }
+    record(leaderboardId, record, expireAt) {
+        const row = Object.assign({}, record);
+        const id = row.id;
+        delete row.id;
+        const score = row.score;
+        delete row.score;
+        const update = {
+            $max: { score: score },
+            $setOnInsert: { createdAt: new Date() },
+        };
+        if (Object.keys(row).length > 0) {
+            update.$set = row;
+        }
+        return new Promise((resolve, reject) => {
+            this.getCollection(leaderboardId).
+                findOneAndUpdate({ id }, update, { upsert: true }).
+                then((r) => resolve(r.ok));
+        });
+    }
+    list(leaderboardId, opts = { limit: 10, skip: 0 }) {
+        return this.getCollection(leaderboardId).
+            find({}).
+            project({ _id: 0 }).
+            sort({ score: -1 }).
+            skip(opts.skip).
+            limit(opts.limit).
+            toArray();
+    }
+    get(leaderboardId, id) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this.getCollection(leaderboardId).findOne({ id });
+        });
+    }
+    count(leaderboardId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return yield this.getCollection(leaderboardId).countDocuments();
+        });
+    }
+    position(leaderboardId, id) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const user = yield this.get(leaderboardId, id);
+            return (yield this.getCollection(leaderboardId).
+                find({
+                score: {
+                    $gt: user.score
+                }
+            }).
+                count()) + 1;
+        });
+    }
+    surrounding(leaderboardId, id, opts = { limit: 5 }) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const collection = this.getCollection(leaderboardId);
+            const user = yield collection.findOne({ id });
+            const [before, after] = yield Promise.all([
+                collection.
+                    find({ id: { $ne: id }, score: { $lte: user.score } }).
+                    project({ _id: 0 }).
+                    sort({ score: -1 }).
+                    limit(opts.limit).
+                    toArray(),
+                collection.
+                    find({ id: { $ne: id }, score: { $gte: user.score } }).
+                    project({ _id: 0 }).
+                    sort({ score: 1 }).
+                    limit(opts.limit).
+                    toArray(),
+            ]);
+            return after.reverse().concat(user).concat(before);
+        });
+    }
+    getCollection(leaderboardId) {
+        return this.db.collection(`lb_${leaderboardId}`);
+    }
+}
+exports.Leaderboard = Leaderboard;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,1 @@
+export { Leaderboard } from './Leaderboard';

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,4 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var Leaderboard_1 = require("./Leaderboard");
+exports.Leaderboard = Leaderboard_1.Leaderboard;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "test": "mocha --require ts-node/register test/**Test.ts",
+    "test": "mocha --require ts-node/register test/**Test.ts --timeout 100000",
     "tslint": "tslint --project .",
     "prepublish": "tsc"
   },

--- a/src/Leaderboard.ts
+++ b/src/Leaderboard.ts
@@ -7,6 +7,7 @@ export interface CreateOptions {
 
 export interface ListOptions {
     limit?: number;
+    skip?: number;
 }
 
 export interface RecordOptions {
@@ -69,17 +70,22 @@ export class Leaderboard {
         });
     }
 
-    public list(leaderboardId: string, opts: ListOptions = { limit: 10 }) {
+    public list(leaderboardId: string, opts: ListOptions = { limit: 10, skip: 0 }) {
         return this.getCollection(leaderboardId).
             find({}).
             project({ _id: 0 }).
             sort({ score: -1 }).
+            skip(opts.skip).
             limit(opts.limit).
             toArray();
     }
 
     public async get(leaderboardId: string, id: any) {
         return await this.getCollection(leaderboardId).findOne({ id });
+    }
+
+    public async count(leaderboardId: string) {
+        return await this.getCollection(leaderboardId).countDocuments()
     }
 
     public async position(leaderboardId: string, id: any) {

--- a/test/LeaderboarTest.ts
+++ b/test/LeaderboarTest.ts
@@ -130,6 +130,41 @@ describe("Leaderboard", () => {
         });
     });
 
+    it("should count positions in a leaderboard", async () => {
+        await leaderboard.record(TEST_LEADERBOARD, { id: "player1", score: 10 });
+        await leaderboard.record(TEST_LEADERBOARD, { id: "player2", score: 30 });
+        await leaderboard.record(TEST_LEADERBOARD, { id: "player3", score: 50 });
+        await leaderboard.record(TEST_LEADERBOARD, { id: "player4", score: 25 });
+        await leaderboard.record(TEST_LEADERBOARD, { id: "player5", score: 1 });
+        await leaderboard.record(TEST_LEADERBOARD, { id: "player6", score: 3 });
+        await leaderboard.record(TEST_LEADERBOARD, { id: "player7", score: 60 });
+
+        let count = await leaderboard.count(TEST_LEADERBOARD)
+        assert.equal(count, 7);
+    });
+
+    it("should return record according skip and limit", async () => {
+        await leaderboard.record(TEST_LEADERBOARD, { id: "player1", score: 10 });
+        await leaderboard.record(TEST_LEADERBOARD, { id: "player2", score: 30 });
+        await leaderboard.record(TEST_LEADERBOARD, { id: "player3", score: 50 });
+        await leaderboard.record(TEST_LEADERBOARD, { id: "player4", score: 25 });
+
+        const all = await leaderboard.list(TEST_LEADERBOARD);
+        assert.equal(all.length, 4)
+
+        const firstHalf = await leaderboard.list(TEST_LEADERBOARD, { limit: 2, skip: 0 });
+        assert.equal(firstHalf[0].score, 50);
+        assert.equal(firstHalf[1].score, 30);
+
+        const secondHalf = await leaderboard.list(TEST_LEADERBOARD, { limit: 2, skip: 2});
+        assert.equal(secondHalf[0].score, 25);
+        assert.equal(secondHalf[1].score, 10);
+
+        const emptyArray = await leaderboard.list(TEST_LEADERBOARD, { limit: 2, skip: 4});
+        assert.equal(emptyArray.length, 0)
+    });
+
+
     xit("should list scores from leaderboard (this test takes a minute to resolve)", async () => {
         const name = "one_second_leaderboard";
         await leaderboard.create(name, { ttl: 0.0001 });


### PR DESCRIPTION
Added 
- `.count()` method that counts all records in a leaderboard
- `{ skip: number }` option to the `.list()` method